### PR TITLE
Fix unicode string encodings

### DIFF
--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -1,3 +1,3 @@
 # see LICENSE
 
-VERSION = (0, 5, 15)
+VERSION = (0, 5, 16)

--- a/messaging/mms/mms_pdu.py
+++ b/messaging/mms/mms_pdu.py
@@ -806,7 +806,7 @@ class MMSEncoder(wsp_pdu.Encoder):
             message_body.extend(encoded_part_headers)
             # Data (note: we do not null-terminate this)
             for char in part.data:
-                message_body.append(ord(char))
+                message_body.frombytes(char.encode())
 
         return message_body
 


### PR DESCRIPTION
```python
import array

a = "Using 语言处理 special ô char 😂"
b1 = array.array('B')
b2 = array.array('B')

for c in a:
    b1.frombytes(c.encode())

assert b2.tobytes().decode() == a
```
^ This works ^